### PR TITLE
Make extractor treat `+intl-icu` suffixed domains as separate domains

### DIFF
--- a/Tests/Util/FileUtilsTest.php
+++ b/Tests/Util/FileUtilsTest.php
@@ -95,11 +95,11 @@ class FileUtilsTest extends TestCase
 
         $files = FileUtils::findTranslationFiles($this->translationDirectory);
 
-        $this->assertArrayHasKey('messages', $files);
-        $this->assertArrayHasKey('en_GB', $files['messages']);
-        $this->assertEquals('xliff', $files['messages']['en_GB'][0]);
-        $this->assertInstanceOf(SplFileInfo::class, $files['messages']['en_GB'][1]);
-        $this->assertTrue($files['messages']['en_GB'][2]);
+        $this->assertArrayHasKey('messages+intl-icu', $files);
+        $this->assertArrayHasKey('en_GB', $files['messages+intl-icu']);
+        $this->assertEquals('xliff', $files['messages+intl-icu']['en_GB'][0]);
+        $this->assertInstanceOf(SplFileInfo::class, $files['messages+intl-icu']['en_GB'][1]);
+        $this->assertTrue($files['messages+intl-icu']['en_GB'][2]);
     }
 
     /**

--- a/Util/FileUtils.php
+++ b/Util/FileUtils.php
@@ -46,7 +46,7 @@ abstract class FileUtils
         $files = [];
         foreach (Finder::create()->in($directory)->depth('< 1')->files() as $file) {
             $isTranslationFile = preg_match(
-                '/^(?P<domain>[^\.]+?)(?P<icu>\+intl-icu)?\.(?P<locale>[^\.]+)\.(?P<format>[^\.]+)$/',
+                '/^(?P<domain>[^\.]+?(?P<icu>\+intl-icu)?)\.(?P<locale>[^\.]+)\.(?P<format>[^\.]+)$/',
                 basename((string) $file),
                 $match
             );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | Apache2


## Description

This is Lingoda specific patch.

On front-end we want to add support of ICU translation format so we can handle complex translations (like ordinals for example). To make that happen icu format translations should be stored under `+intl-icu` suffixed domain files. So we basically add this suffix in front-end code to certain translations and expect extractor to pull this translations in corresponding suffixed files.

However this only works on first extraction and fail on every subsequent run of extractor, particular the `--dry-run` we use in CI to check whether our translations are okey.

The reason for that is in lines that I edited: when extractor encounter two files `my-domain.<locale>.xliff` and `my-domain+intl-icu.<locale>.xliff` to create a collection of translations for further comparisons it strips `+intl-icu` part and treat only `my-domain` as domain and as a key for a collection values. This results in content of two files not living alongside each other, but rather override each other in that comparator collection, which lead to comparator of code content and `xliff` content to always produce diff, which lead to CI fail.

In another words, current version of the package doesn't allow suffixed and unsuffixed domains to exist at the same time.

Solutions:

a) Migrate everything to `+intl-icu`, which will be huge change, since we gonna need to replace all `%` placeholders with `{}`, re upload everything to lingohub and etc. Not the best option.

b) **Allow both suffixed and unsuffixed domains to coexist at the same time. This is the path I selected in this pr.**
It can cause issues if at some point of time we gonna migrate all files to icu format with suffixed files, but we can just revert this pr in this case.

## Todos
- [x] Tests
- [x] Documentation
- [ ] Changelog
